### PR TITLE
Add in support for changing the status of GE Link Light Bulbs

### DIFF
--- a/src/devices/geLinkLightbulb.php
+++ b/src/devices/geLinkLightbulb.php
@@ -1,0 +1,105 @@
+<?php
+
+/**
+ * Wink SDK for PHP
+ * 
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ * See the file license.txt for copying permission.
+ * 
+ * @author    Ian Maddox <oss@ianmaddox.com>
+ * @copyright 2014
+ * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
+ */
+
+namespace ianmaddox\wink\devices;
+
+/**
+ * The GE Link bulb device parent class. This class allows you access to device-level data on the GE Link bulb,
+ * from device naming, to sharing, and state changes.
+ */
+class geLinkLightbulb extends \ianmaddox\wink\device {
+
+	/**
+	 * Return the ID of this wink object
+	 * @return int
+	 */
+	public function getID() {
+		return $this->deviceData['light_bulb_id'];
+	}
+
+	/**
+	 * Set the current state of the device. Specifically
+	 * for this device is the powered state (boolean)
+	 * and the brightness state (range of float 0.0-1.0)
+	 * @return array;
+	 */
+	public function setState($powered, $brightness) {
+		$action = '/light_bulbs/@';
+		$args = array('light_bulb_id' => $this->deviceID);
+
+		if ($powered !== true && $powered !== false) {
+			trigger_error("The GE Link Bulb only has 'true' or 'false' as an accepted powered state. Cannot change desired powered state on bulb to '$powered'", E_USER_WARNING);
+			return false;
+		}
+
+		if ($brightness < 1.0 || $powered > 1.0) {
+			trigger_error("The GE Link Bulb only has the range 0.0 through 1.0 as an accepted brightness levels. Cannot change desired brightness level on bulb to '$brightness'", E_USER_WARNING);
+			return false;
+		}
+
+		$data = array(
+			'desired_state' => array(
+				"powered" => $powered,
+				"brightness" => $brightness
+			)
+		);
+
+		return $this->wink->doRequest($action, $data, $args, 'PUT');
+	}
+
+	/**
+	 * Return all available data about the device
+	 * @return array
+	 */
+	public function getLightbulb() {
+		$action = '/light_bulbs/@';
+		$args = array('light_bulb_id' => $this->deviceID);
+		return $this->wink->doRequest($action, array(), $args);
+	}
+
+	/**
+	 * Change the device's friendly name
+	 * 
+	 * @param string $name
+	 * @return object
+	 */
+	public function renameDevice($name) {
+		$action = '/light_bulbs/@';
+		$args = array('light_bulb_id' => $this->deviceID);
+		$data = array('name' => $name);
+		return $this->wink->doRequest($action, $data, $args, 'PUT');
+	}
+
+	/**
+	 * List the users who have access to this GE Link Bulb
+	 * @link http://docs.wink.apiary.io/#get-%2Flight_bulbs%2F%7Blight_bulb_id%7D%2Fusers
+	 * @return object
+	 */
+	public function getLightbulbUsers() {
+		$action = '/light_bulbs/@/users';
+		$args = array('light_bulb_id' => $this->deviceID);
+		return $this->wink->doRequest($action, array(), $args);
+	}
+
+	public function unshareLightbulb() {
+		trigger_error("Method not yet implemented", E_USER_WARNING);
+		$action = '/light_bulbs/@/users';
+	}
+
+	public function shareLightbulb() {
+		trigger_error("Method not yet implemented", E_USER_WARNING);
+		$action = '/light_bulbs/@/users/@';
+	}
+
+}

--- a/src/devices/geLinkLightbulb.php
+++ b/src/devices/geLinkLightbulb.php
@@ -43,7 +43,7 @@ class geLinkLightbulb extends \ianmaddox\wink\device {
 			return false;
 		}
 
-		if ($brightness < 1.0 || $powered > 1.0) {
+		if ($brightness < 0.0 || $brightness > 1.0) {
 			trigger_error("The GE Link Bulb only has the range 0.0 through 1.0 as an accepted brightness levels. Cannot change desired brightness level on bulb to '$brightness'", E_USER_WARNING);
 			return false;
 		}

--- a/src/wink.php
+++ b/src/wink.php
@@ -28,6 +28,7 @@ class wink {
 	const DEVICE_PIVOTPOWERGENIUS = 'pivotPowerGenius';
 	const DEVICE_PORKFOLIO = 'porkfolio';
 	const DEVICE_SPOTTER = 'spotter';
+	const DEVICE_GELINK_LIGHTBULB = 'geLinkLightbulb';
 
 	private $access_token;
 	private $refresh_token;
@@ -38,7 +39,8 @@ class wink {
 		'eggtray_id' => self::DEVICE_EGGMINDER,
 		'powerstrip_id' => self::DEVICE_PIVOTPOWERGENIUS,
 		'piggy_bank_id' => self::DEVICE_PORKFOLIO,
-		'sensor_pod_id' => self::DEVICE_SPOTTER
+		'sensor_pod_id' => self::DEVICE_SPOTTER,
+		'light_bulb_id' => self::DEVICE_GELINK_LIGHTBULB
 	);
 	
 	private $debug = 1;


### PR DESCRIPTION
Heya!

Added in support for changing the status of a GE Link Light Bulb. Only added in the general things (rename, turn on, turn off, brightness level). Hope it's alright. I tried to stick to your coding standards that I observed.

I used the template of yours to base this off of, I plan on buying more Wink devices in the coming weeks so I'll be adding support for more if interested (Honeywell Wi-Fi Thermostat, Lutron Switches / Outlets).